### PR TITLE
Feat: Mostrar conteo de votos y cronometro

### DIFF
--- a/src/services/ReunionService.ts
+++ b/src/services/ReunionService.ts
@@ -10,7 +10,10 @@ export class ReunionService {
         if (reunionData.hora_fin && new Date(reunionData.hora_inicio) >= new Date(reunionData.hora_fin)) {
             throw new Error('La hora de inicio debe ser anterior a la hora de fin.');
         }
-
+        // Convertir hora_inicio a Date y ajustar a UTC-6
+        const horaInicio = new Date(reunionData.hora_inicio);
+        horaInicio.setHours(horaInicio.getHours() - 6);
+        reunionData.hora_inicio = horaInicio;
         return this.reunionDAO.create(reunionData);
     }
 


### PR DESCRIPTION
Se implemento un cronometro en el frontend de la reunion
- El cronometro muestra el tiempo estimado
- Muestra la cantidad de minutos que falta
- Muestra la duracion real
- Guarda la duracion real en el punto (hay que presionar el boton)

Se implemento para aquellos puntos que son de aprobacion, una seccion para poner la cantidad de puntos en contra y a favor
- Se puso la restriccion de votos totales de acuerdo a la cantidad de invitados
- Se guarda la cantidad de votaciones al presionar el boton guardar punto